### PR TITLE
Moved test code into separate package

### DIFF
--- a/langdet/analyzing.go
+++ b/langdet/analyzing.go
@@ -14,13 +14,13 @@ var maxSampleSize = 10000
 
 // Analyze creates the language profile from a given Text and returns it in a Language struct.
 func Analyze(text, name string) Language {
-	theMap := createOccurenceMap(text, nDepth)
-	ranked := createRankLookupMap(theMap)
+	theMap := CreateOccurenceMap(text, nDepth)
+	ranked := CreateRankLookupMap(theMap)
 	return Language{Name: name, Profile: ranked}
 }
 
 // creates the map [token] rank from a map [token] occurrence
-func createRankLookupMap(input map[string]int) map[string]int {
+func CreateRankLookupMap(input map[string]int) map[string]int {
 	tokens := make([]Token, len(input))
 	counter := 0
 	for k, v := range input {
@@ -40,9 +40,9 @@ func createRankLookupMap(input map[string]int) map[string]int {
 	return result
 }
 
-// createOccurenceMap creates a map[token]occurrence from a given text and up to a given gram depth
+// CreateOccurenceMap creates a map[token]occurrence from a given text and up to a given gram depth
 // gramDepth=1 means only 1-letter tokens are created, gramDepth=2 means 1- and 2-letters token are created, etc.
-func createOccurenceMap(text string, gramDepth int) map[string]int {
+func CreateOccurenceMap(text string, gramDepth int) map[string]int {
 	text = cleanText(text)
 	tokens := strings.Split(text, " ")
 	result := make(map[string]int)

--- a/langdet/analyzing_test.go
+++ b/langdet/analyzing_test.go
@@ -1,4 +1,4 @@
-package langdet
+package langdet_test
 
 import (
 	. "github.com/smartystreets/goconvey/convey"

--- a/langdet/analyzing_test.go
+++ b/langdet/analyzing_test.go
@@ -2,6 +2,7 @@ package langdet_test
 
 import (
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/chrisport/go-lang-detector/langdet"
 	"testing"
 )
 
@@ -9,7 +10,7 @@ func BenchmarkCalculateElapsedTimeInMillis(b *testing.B) {
 	sampleText := "TEXT"
 
 	for n := 0; n < b.N; n++ {
-		_ = createOccurenceMap(sampleText, 5)
+		_ = langdet.CreateOccurenceMap(sampleText, 5)
 	}
 
 }
@@ -18,7 +19,7 @@ func TestCreateProfile(t *testing.T) {
 	sampleText := "TEXT"
 	Convey("Subject: Test create profile\n", t, func() {
 		Convey("result of 'TEXT' should contain when n=3:  T:2, E:1, X:1, T:1, ...", func() {
-			result := createOccurenceMap(sampleText, 3)
+			result := langdet.CreateOccurenceMap(sampleText, 3)
 			So(result["T"], ShouldEqual, 2)
 			So(result["E"], ShouldEqual, 1)
 			So(result["X"], ShouldEqual, 1)
@@ -42,7 +43,7 @@ func TestCreateProfileWithObscure(t *testing.T) {
 	sampleText := "...TE X123123T"
 	Convey("Subject: Test create profile\n", t, func() {
 		Convey("result of 'TEXT' should contain when n=3:  T:2, E:1, X:1, T:1, ...", func() {
-			result := createOccurenceMap(sampleText, 3)
+			result := langdet.CreateOccurenceMap(sampleText, 3)
 			So(result["T"], ShouldEqual, 2)
 			So(result["E"], ShouldEqual, 1)
 			So(result["X"], ShouldEqual, 1)
@@ -68,8 +69,8 @@ func TestRanking(t *testing.T) {
 	sampleText := "AABBCC"
 	Convey("Subject: Test create Ranking Lookup Map\n", t, func() {
 		Convey("AABBCC should result in A, B and C on rank 1-3", func() {
-			result := createOccurenceMap(sampleText, 5)
-			ranking := createRankLookupMap(result)
+			result := langdet.CreateOccurenceMap(sampleText, 5)
+			ranking := langdet.CreateRankLookupMap(result)
 			So(ranking["A"], ShouldBeBetween, 0, 4)
 			So(ranking["B"], ShouldBeBetween, 0, 4)
 			So(ranking["C"], ShouldBeBetween, 0, 4)

--- a/langdet/detection.go
+++ b/langdet/detection.go
@@ -10,12 +10,12 @@ import (
 // the depth of n-gram tokens that are created. if nDepth=1, only 1-letter tokens are created
 const nDepth = 4
 
-// defaultMinimumConfidence is the minimum confidence that a language-match must have to be returned as detected language
-var defaultMinimumConfidence float32 = 0.7
+// DefaultMinimumConfidence is the minimum confidence that a language-match must have to be returned as detected language
+var DefaultMinimumConfidence float32 = 0.7
 
 var defaultLanguages = []Language{}
 
-var DefaultDetector = Detector{&defaultLanguages, defaultMinimumConfidence}
+var DefaultDetector = Detector{&defaultLanguages, DefaultMinimumConfidence}
 
 func init() {
 	analyzedInput, err := ioutil.ReadFile("default_languages.json")
@@ -52,7 +52,7 @@ type Detector struct {
 // NewDetector returns a new Detector without any language.
 // It can be used to add languages selectively.
 func NewDetector() Detector {
-	return Detector{&[]Language{}, defaultMinimumConfidence}
+	return Detector{&[]Language{}, DefaultMinimumConfidence}
 }
 
 // NewDetectorDefault returns a new Detector with the default languages, if loaded:
@@ -60,7 +60,7 @@ func NewDetector() Detector {
 func NewDefaultLanguages() Detector {
 	defaultCopy := make([]Language, len(defaultLanguages))
 	copy(defaultCopy, defaultLanguages)
-	return Detector{&defaultCopy, defaultMinimumConfidence}
+	return Detector{&defaultCopy, DefaultMinimumConfidence}
 }
 
 // Add language analyzes a text and creates a new Language with given name.
@@ -92,14 +92,14 @@ func (d *Detector) AddLanguage(languages ...Language) {
 // It returns undefined otherwise. Set detector's MinimumConfidence for customization.
 func (d *Detector) GetClosestLanguage(text string) string {
 	if d.MinimumConfidence <= 0 || d.MinimumConfidence > 1 {
-		d.MinimumConfidence = defaultMinimumConfidence
+		d.MinimumConfidence = DefaultMinimumConfidence
 	}
 	if len(*d.Languages) == 0 {
 		fmt.Println("no languages configured for this detector")
 		return "undefined"
 	}
-	occ := createOccurenceMap(text, nDepth)
-	lmap := createRankLookupMap(occ)
+	occ := CreateOccurenceMap(text, nDepth)
+	lmap := CreateRankLookupMap(occ)
 	c := d.closestFromTable(lmap)
 
 	if len(c) == 0 || c[0].Confidence < asPercent(d.MinimumConfidence) {
@@ -110,8 +110,8 @@ func (d *Detector) GetClosestLanguage(text string) string {
 
 // GetLanguages analyzes a text and returns the DetectionResult of all languages of this detector.
 func (d *Detector) GetLanguages(text string) []DetectionResult {
-	occ := createOccurenceMap(text, nDepth)
-	lmap := createRankLookupMap(occ)
+	occ := CreateOccurenceMap(text, nDepth)
+	lmap := CreateRankLookupMap(occ)
 	results := d.closestFromTable(lmap)
 	return results
 }
@@ -127,7 +127,7 @@ func (d *Detector) closestFromTable(lookupMap map[string]int) []DetectionResult 
 	for _, language := range *d.Languages {
 		lSize := len(language.Profile)
 		maxPossibleDistance := lSize * inputSize
-		dist := getDistance(lookupMap, language.Profile, lSize)
+		dist := GetDistance(lookupMap, language.Profile, lSize)
 		relativeDistance := 1 - float64(dist)/float64(maxPossibleDistance)
 		confidence := int(relativeDistance * 100)
 		res = append(res, DetectionResult{Name: language.Name, Confidence: confidence})
@@ -139,7 +139,7 @@ func (d *Detector) closestFromTable(lookupMap map[string]int) []DetectionResult 
 
 // getDistance calculates the out-of-place distance between two Profiles,
 // taking into account only items of mapA, that have a value bigger then 300
-func getDistance(mapA, mapB map[string]int, maxDist int) int {
+func GetDistance(mapA, mapB map[string]int, maxDist int) int {
 	var result int
 	negMaxDist := ((-1) * maxDist)
 	for key, rankA := range mapA {

--- a/langdet/detection_test.go
+++ b/langdet/detection_test.go
@@ -1,4 +1,4 @@
-package langdet
+package langdet_test
 
 import (
 	. "github.com/smartystreets/goconvey/convey"

--- a/langdet/detection_test.go
+++ b/langdet/detection_test.go
@@ -2,6 +2,7 @@ package langdet_test
 
 import (
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/chrisport/go-lang-detector/langdet"
 	"testing"
 )
 
@@ -15,16 +16,16 @@ func createMapRanking(tokensInRank ...string) map[string]int {
 
 func TestNew(t *testing.T) {
 	Convey("Subject: New detector", t, func() {
-		dd := NewDefaultLanguages()
-		d := NewDetector()
+		dd := langdet.NewDefaultLanguages()
+		d := langdet.NewDetector()
 		Convey("Detector should be initialized", func() {
 			So(d.Languages, ShouldNotBeNil)
 			So(dd.Languages, ShouldNotBeNil)
 		})
 	})
 	Convey("Subject: New detector with default languages", t, func() {
-		_ = NewDefaultLanguages()
-		d := NewDetector()
+		_ = langdet.NewDefaultLanguages()
+		d := langdet.NewDetector()
 		Convey("Detector should be initialized", func() {
 			So(d.Languages, ShouldNotBeNil)
 		})
@@ -33,7 +34,7 @@ func TestNew(t *testing.T) {
 
 func TestAddLanguage(t *testing.T) {
 	Convey("Subject: Add Language by text to new Detector", t, func() {
-		d := Detector{}
+		d := langdet.Detector{}
 		So(d.Languages, ShouldBeNil)
 
 		en := "This is an english sentence"
@@ -46,10 +47,10 @@ func TestAddLanguage(t *testing.T) {
 		})
 	})
 	Convey("Subject: Add Language directly to new Detector", t, func() {
-		d := Detector{}
+		d := langdet.Detector{}
 		So(d.Languages, ShouldBeNil)
 
-		d.AddLanguage(Language{Name: "en"})
+		d.AddLanguage(langdet.Language{Name: "en"})
 
 		Convey("Detector should get initialized and the language should be added", func() {
 			So(d.Languages, ShouldNotBeNil)
@@ -63,7 +64,7 @@ func TestClosest(t *testing.T) {
 	Convey("Subject: Test GetClosestLanguage", t, func() {
 		Convey("When finding a closest language", func() {
 			s := "Hello I am english text, what is your language? I really dont know you say?"
-			d := NewDetector()
+			d := langdet.NewDetector()
 			d.AddLanguageFromText(s, "english")
 			d.AddLanguageFromText("Je parles français et toi?", "french")
 			Convey("Should return string with the language name", func() {
@@ -73,7 +74,7 @@ func TestClosest(t *testing.T) {
 		})
 		Convey("When not finding a closest language", func() {
 			s := "Hello I am english text, what is your language? I really dont know you say?"
-			d := NewDetector()
+			d := langdet.NewDetector()
 			d.AddLanguageFromText("Je parles français et toi?", "french")
 			Convey("Should return string \"undefined\"", func() {
 				res := d.GetClosestLanguage(s)
@@ -81,17 +82,17 @@ func TestClosest(t *testing.T) {
 			})
 		})
 		Convey("When invalid minimum confidence", func() {
-			d := NewDetector()
+			d := langdet.NewDetector()
 			d.MinimumConfidence = -19
 			Convey("Should set confidence level to default", func() {
 				_ = d.GetClosestLanguage("asd")
-				So(d.MinimumConfidence, ShouldEqual, defaultMinimumConfidence)
+				So(d.MinimumConfidence, ShouldEqual, langdet.DefaultMinimumConfidence)
 			})
 		})
 	})
 	Convey("Subject: Test GetLanguages", t, func() {
 		s := "Hello I am english text"
-		d := NewDetector()
+		d := langdet.NewDetector()
 		d.AddLanguageFromText(s, "english")
 		d.AddLanguageFromText("Je parles français et toi?", "french")
 		Convey("Should return array with DetectionResults containing all languages", func() {
@@ -108,28 +109,28 @@ func TestGetDistance(t *testing.T) {
 		Convey("same profiles should return distance 0", func() {
 			rankMapA := createMapRanking("a", "b", "c")
 			rankMapB := createMapRanking("a", "b", "c")
-			dist := getDistance(rankMapA, rankMapB, 10)
+			dist := langdet.GetDistance(rankMapA, rankMapB, 10)
 			So(dist, ShouldBeZeroValue)
 		})
 
 		Convey("same profiles with 1 rank swapped should return distance 2", func() {
 			rankMapA := createMapRanking("a", "b", "c")
 			rankMapB := createMapRanking("a", "c", "b")
-			dist := getDistance(rankMapA, rankMapB, 10)
+			dist := langdet.GetDistance(rankMapA, rankMapB, 10)
 			So(dist, ShouldEqual, 2)
 		})
 
 		Convey("same profiles except 1 token different should return distance 10 when maxDifference is 10", func() {
 			rankMapA := createMapRanking("a", "b", "c")
 			rankMapB := createMapRanking("a", "b", "d")
-			dist := getDistance(rankMapA, rankMapB, 10)
+			dist := langdet.GetDistance(rankMapA, rankMapB, 10)
 			So(dist, ShouldEqual, 10)
 		})
 
 		Convey("entirely different profiles with 3 tokens should return distance 30 if maxDistance is set to 10", func() {
 			rankMapA := createMapRanking("a", "b", "c")
 			rankMapB := createMapRanking("e", "f", "g")
-			dist := getDistance(rankMapA, rankMapB, 10)
+			dist := langdet.GetDistance(rankMapA, rankMapB, 10)
 			So(dist, ShouldEqual, 30)
 
 		})


### PR DESCRIPTION
This will get rid of test command line flags when someone uses `flags` package
```
 -test.bench string
        regular expression to select benchmarks to run
  -test.benchmem
        print memory allocations for benchmarks
  -test.benchtime duration
```