### PR TITLE
Fixed incorrect function name NewDefaultDetector in readme example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The default detector supports the following languages:
 **Arabic, English, French, German, Hebrew, Russian, Turkish**
 
 ``` go
-    detector := langdet.NewDefaultDetector()
+    detector := langdet.NewDefaultLanguages()
 	testString := "do not care about quantity"
 	result := detector.GetClosestLanguage(testString)
 	fmt.Println(result)

--- a/langdet/detection.go
+++ b/langdet/detection.go
@@ -70,7 +70,7 @@ func NewDetector() Detector {
 	return Detector{&[]Language{}, DefaultMinimumConfidence}
 }
 
-// NewDetectorDefault returns a new Detector with the default languages, if loaded:
+// NewDefaultLanguages returns a new Detector with the default languages, if loaded:
 // currently: Arabic, English, French, German, Hebrew, Russian, Turkish
 func NewDefaultLanguages() Detector {
 	defaultCopy := make([]Language, len(defaultLanguages))


### PR DESCRIPTION
It seems like the function to create a new detector with default languages changed from `NewDefaultDetector` or `NewDetectorDefault` to `NewDefaultLanguages` and the name in the readme as well as the function header did not get updated. 

Is this the correct name substitution?